### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
   ],
   "dependencies": {
     "chalk": "^1.1.1",
-    "generator-jasmine": "^0.2.2",
-    "generator-mocha": "^0.3.0",
-    "istanbul": "^0.4.2",
     "mkdirp": "^0.5.1",
     "underscore.string": "^3.2.3",
     "wiredep": "^4.0.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 3/9 of the direct dependencies are installed, however, they are not used during test runtime. We moved these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?